### PR TITLE
Extract upstream pkgrepo to be an optional include

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,11 @@ Install jenkins from the source package repositories and start it up.
 
 Add a jenkins nginx entry. 
 
+``jenkins.pkgrepo``
+-----------------
+
+Add and use the upstream jenkins-ci.org package repository instead of the default. (apt/yum only)
+
 Pillar customizations:
 ==========================
 

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -24,19 +24,8 @@ jenkins_user:
       - group: jenkins_group
 
 jenkins:
-  pkgrepo.managed:
-    - humanname: Jenkins upstream package repository
-    {% if grains['os_family'] == 'RedHat' %}
-    - baseurl: http://pkg.jenkins-ci.org/redhat
-    - gpgkey: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
-    {% elif grains['os_family'] == 'Debian' %}
-    - name: deb http://pkg.jenkins-ci.org/debian binary/
-    - key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
-    {% endif %}
   pkg.latest:
     - refresh: True
-    - require:
-      - pkgrepo: jenkins
   service.running:
     - enable: True
     - watch:

--- a/jenkins/pkgrepo.sls
+++ b/jenkins/pkgrepo.sls
@@ -1,0 +1,20 @@
+include:
+  - jenkins
+
+jenkins_pkgrepo:
+  pkgrepo.managed:
+    - name: jenkins
+    - humanname: Jenkins upstream package repository
+    {% if grains['os_family'] == 'RedHat' %}
+    - baseurl: http://pkg.jenkins-ci.org/redhat
+    - gpgkey: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
+    {% elif grains['os_family'] == 'Debian' %}
+    - name: deb http://pkg.jenkins-ci.org/debian binary/
+    - key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
+    {% endif %}
+
+extend:
+  jenkins:
+    pkg:
+      - require:
+        - pkgrepo: jenkins


### PR DESCRIPTION
This should resolve https://github.com/saltstack-formulas/jenkins-formula/issues/5  . It will require existing/new users to include jenkins.pkgrepo if they want to use the jenkins-ci.org packages.
