### PR TITLE
Changing require to require_in

### DIFF
--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -34,13 +34,11 @@ jenkins:
     - name: deb http://pkg.jenkins-ci.org/debian binary/
     - key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
     {% endif %}
+    - require_in: 
+      - pkg: jenkins
   {% endif %}
   pkg.latest:
     - refresh: True
-    {% if grains['os_family'] in ['RedHat', 'Debian'] %}
-    - require:
-      - pkgrepo: jenkins
-    {% endif %}
   service.running:
     - enable: True
     - watch:


### PR DESCRIPTION
As @moreda brought up in a comment on https://github.com/saltstack-formulas/jenkins-formula/commit/18c423f5f5f783bd31225c2d710c382b7d536b62 :

```
 - require:
       - pkgrepo: jenkins
```

won't work as expected because pkgrepo is expected to be used via "require_in" according to http://docs.saltstack.com/en/latest/ref/states/all/salt.states.pkgrepo.html#management-of-apt-yum-package-repos

```
require_in
    Set this to a list of pkg.installed or pkg.latest to trigger the running of apt-get update prior to attempting to install these packages. Setting a require in the pkg will not work for this.
```
