### PR TITLE
Enable configuring jenkins server_name

### DIFF
--- a/jenkins/files/nginx.conf
+++ b/jenkins/files/nginx.conf
@@ -8,7 +8,10 @@ upstream app_server {
 server {
     listen {{ port }};
     listen [::]:{{ port }} default ipv6only=on;
-    # server_name ci.{{grains['id']}}.com;
+
+    {% if 'server_name' in jenkins %}
+    server_name {{ jenkins.server_name }};
+    {% endif %}
 
     location / {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This way, jenkins doesn't have the exclusivity on Nginx.