### PR TITLE
Added .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: python
+python:
+  - '2.7'
+
+env:
+  global:
+    - BS_PIP_ALLOWED=1
+    - BS_ECHO_DEBUG=1
+    - SALT_ARGS="-l debug --local --retcode-passthrough --pillar-root=test/pillar --file-root=$PWD"
+  matrix:
+    - STATE=jenkins
+    - STATE=jenkins,jenkins.nginx
+
+before_install:
+  - sudo apt-get update
+  - curl -L http://bootstrap.saltstack.org | sudo -E sh -s -- stable
+
+install:
+  - sudo mkdir -p /srv && sudo ln -sfn $PWD /srv/formula
+  # See what kind of travis box you're on to help with making your states
+  # compatible with travis
+  - sudo salt-call grains.items --local
+  - if [ $STATE == 'jenkins,jenkins.nginx' ]; then sudo git clone https://github.com/saltstack-formulas/nginx-formula.git $PWD/nginx-formula; ln -sfn $PWD/nginx-formula/nginx $PWD/nginx; fi
+
+script:
+  - sudo -E salt-call state.show_sls $STATE $SALT_ARGS
+  - sudo -E salt-call state.sls $STATE $SALT_ARGS
+
+  # Idempotence check
+  - sudo -E salt-call state.sls $STATE $SALT_ARGS > /tmp/second
+  - cat /tmp/second
+  - bash -c '! grep -q "^Not Run:" /tmp/second'

--- a/test/pillar/example.sls
+++ b/test/pillar/example.sls
@@ -1,0 +1,1 @@
+../../pillar.example

--- a/test/pillar/top.sls
+++ b/test/pillar/top.sls
@@ -1,0 +1,3 @@
+base:
+  '*':
+    - example


### PR DESCRIPTION
This should let you know easily if a PR breaks anything !

See it in action: https://travis-ci.org/jpic/jenkins-formula

It's interresting to see that jenkins.nginx includes nginx but not jenkins. If it did, it would look a bit cleaner (ie. we could replace `jenkins,jenkins.nginx` by just `jenkins.nginx` in this PR).