### PR TITLE
Fix #23: Provision jenkins plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     - STATE=jenkins
     - STATE=jenkins,nginx,jenkins.nginx
+    - STATE=jenkins,jenkins.plugins
 
 before_install:
   - sudo apt-get update

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -5,5 +5,12 @@
         'home': '/var/lib/jenkins',
         'port': '80',
         'server_name': None,
+        'cli': 'java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
+        'master_url': None,
+        'plugins': {
+            'plugin_list': '/tmp/jenkins_plugin_list',
+            'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
+            'installed': [],
+        },
     },
 }, merge=salt['pillar.get']('jenkins:lookup')) %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -1,0 +1,52 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+
+jenkins_updates_downloader:
+  pkg.installed:
+    - name: curl
+
+jenkins_updates_directory:
+  file.directory:
+    - name: {{ jenkins.home }}/updates/
+    - user: {{ jenkins.user }}
+    - group: {{ jenkins.group }}
+    - makedirs: True
+
+jenkins_updates_file:
+  cmd.run:
+    - unless: test -f /var/lib/jenkins/updates/default.json
+    - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ jenkins.home }}/updates/default.json"
+
+jenkins_started:
+  service.running:
+    - name: jenkins
+    - watch:
+      - cmd: jenkins_updates_file
+
+jenkins_plugin_list:
+  cmd.run: 
+    - name: until {{ jenkins.cli }} list-plugins > {{ jenkins.plugins.plugin_list }} 2> /dev/null; do sleep 1; done
+    - env: 
+      - JENKINS_URL: {{ jenkins.master_url }}
+    - timeout: 120
+    - require:
+      - service: jenkins_started
+
+{% for plugin in jenkins.plugins.installed %}
+jenkins_install_plugin_{{ plugin }}:
+  cmd.run:
+    - unless: grep {{ plugin }} {{ jenkins.plugins.plugin_list }}
+    - name: until {{ jenkins.cli }} install-plugin {{ plugin }}; do sleep 1; done
+    - timeout: 360
+    - env: 
+      - JENKINS_URL: {{ jenkins.master_url }}
+    - require:
+      - cmd: jenkins_plugin_list
+{% endfor %}
+
+jenkins_restart_for_plugins:
+  service.running:
+    - name: jenkins
+    - watch:
+      {% for plugin in jenkins.plugins.installed %}
+      - cmd: jenkins_install_plugin_{{ plugin }}
+      {% endfor %}

--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,8 @@
 jenkins:
   lookup:
     home: /usr/local/jenkins
-    server_name: ci.example.com
+    server_name: localhost
+    master_url: http://localhost:8080
+    plugins:
+      installed:
+        - greenballs


### PR DESCRIPTION
Ok so I tried to shrink it as much as I could, not so easy but thanks to the
until trick we are able to manage jenkins in an automated way without too much
boilerplate.

If you prefer the version from pasted code in #23 please let me know, it's a
bit sharper, but there's a lot more boilerplate code.

Let me know which improvements to make.