### PR TITLE
Fix #23: Provision jenkins plugins

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   matrix:
     - STATE=jenkins
     - STATE=jenkins,nginx,jenkins.nginx
+    - STATE=jenkins,jenkins.plugins
 
 before_install:
   - sudo apt-get update

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,8 @@ script:
   - sudo -E salt-call state.show_sls $STATE $SALT_ARGS
   - sudo -E salt-call state.sls $STATE $SALT_ARGS
 
+  - sudo iptables -A INPUT -p tcp --dport 8080 -j ACCEPT
+
   # Idempotence check
   - sudo -E salt-call state.sls $STATE $SALT_ARGS > /tmp/second
   - cat /tmp/second

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -12,6 +12,7 @@
             'plugin_list': '/tmp/jenkins_plugin_list',
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
             'installed': [],
+            'disabled': [],
         },
     },
 }, merge=salt['pillar.get']('jenkins:lookup')) %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -5,6 +5,13 @@
         'group': 'jenkins',
         'home': '/var/lib/jenkins',
         'port': '80',
-        'server_name': None
+        'server_name': None,
+        'cli': 'java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
+        'master_url': None,
+        'plugins': {
+            'plugin_list': '/tmp/jenkins_plugin_list',
+            'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
+            'installed': [],
+        },
     },
 }, merge=salt['pillar.get']('jenkins:lookup')) %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -6,7 +6,7 @@
         'home': '/var/lib/jenkins',
         'port': '80',
         'server_name': None,
-        'cli': 'java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
+        'cli_path': '/var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
         'master_url': 'http://localhost:8080',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -1,10 +1,12 @@
 {% set jenkins = salt['grains.filter_by']({
     'default': {
         'pkgs': ['jenkins'],
+        'netcat_pkg': 'netcat-openbsd',
         'user': 'jenkins',
         'group': 'jenkins',
         'home': '/var/lib/jenkins',
         'port': '80',
+        'jenkins_port': 8080,
         'server_name': None,
         'cli_path': '/var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
         'master_url': 'http://localhost:8080',

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -9,7 +9,6 @@
         'cli': 'java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
         'master_url': None,
         'plugins': {
-            'plugin_list': '/tmp/jenkins_plugin_list',
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
             'installed': [],
             'disabled': [],

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -7,7 +7,7 @@
         'port': '80',
         'server_name': None,
         'cli': 'java -jar /var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
-        'master_url': None,
+        'master_url': 'http://localhost:8080',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
             'installed': [],

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -13,6 +13,12 @@ include:
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}
 
 jenkins_updates_file:
+  file.directory:
+    - name: {{ "{0}/updates".format(jenkins.home) }}
+    - user: {{ jenkins.user }}
+    - group: {{ jenkins.group }}
+    - mode: 755
+
   pkg.installed:
     - name: curl
 
@@ -22,6 +28,7 @@ jenkins_updates_file:
     - require:
       - pkg: jenkins
       - pkg: jenkins_updates_file
+      - file: jenkins_updates_file
 
 restart_jenkins:
   cmd.wait:

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -7,7 +7,7 @@ include:
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
 {%- macro jenkins_cli(cmd, strargs) -%}
-{{ ' '.join([jenkins.cli, fmtarg('-s', jenkins.get('master_url')), fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
+{{ ' '.join([jenkins.cli, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
 {%- endmacro -%}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -18,7 +18,7 @@ jenkins_updates_file:
 
   cmd.run:
     - unless: test -f {{ plugin_cache }}
-    - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ plugin_cache }}"
+    - name: "curl -L {{ jenkins.plugins.updates_source }} | sed '1d;$d' > {{ plugin_cache }}"
     - require:
       - pkg: jenkins
       - pkg: jenkins_updates_file

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -7,7 +7,7 @@ include:
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
 {%- macro jenkins_cli(cmd, strargs) -%}
-{{ ' '.join([jenkins.cli, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
 {%- endmacro -%}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -10,13 +10,18 @@ include:
 {{ ' '.join([jenkins.cli, fmtarg('-s', jenkins.get('master_url')), fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
 {%- endmacro -%}
 
+{% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}
+
 jenkins_updates_file:
+  pkg.installed:
+    - name: curl
+
   cmd.run:
-    - onlyif: test -d {{ jenkins.home }}/updates
-    - unless: test -f {{ jenkins.home }}/updates/default.json
-    - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ jenkins.home }}/updates/default.json"
+    - unless: test -f {{ plugin_cache }}
+    - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ plugin_cache }}"
     - require:
       - pkg: jenkins
+      - pkg: jenkins_updates_file
 
 restart_jenkins:
   cmd.wait:

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -1,0 +1,52 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+
+jenkins_updates_downloader:
+  pkg.installed:
+    - name: curl
+
+jenkins_updates_directory:
+  file.directory:
+    - name: {{ jenkins.home }}/updates/
+    - user: {{ jenkins.user }}
+    - group: {{ jenkins.group }}
+    - makedirs: True
+
+jenkins_updates_file:
+  cmd.run:
+    - unless: test -f /var/lib/jenkins/updates/default.json
+    - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ jenkins.home }}/updates/default.json"
+
+jenkins_started:
+  service.running:
+    - name: jenkins
+    - watch:
+      - cmd: jenkins_updates_file
+
+jenkins_plugin_list:
+  cmd.run:
+    - name: until {{ jenkins.cli }} list-plugins > {{ jenkins.plugins.plugin_list }} 2> /dev/null; do sleep 1; done
+    - env:
+      - JENKINS_URL: {{ jenkins.master_url }}
+    - timeout: 120
+    - require:
+      - service: jenkins_started
+
+{% for plugin in jenkins.plugins.installed %}
+jenkins_install_plugin_{{ plugin }}:
+  cmd.run:
+    - unless: grep {{ plugin }} {{ jenkins.plugins.plugin_list }}
+    - name: until {{ jenkins.cli }} install-plugin {{ plugin }}; do sleep 1; done
+    - timeout: 360
+    - env:
+      - JENKINS_URL: {{ jenkins.master_url }}
+    - require:
+      - cmd: jenkins_plugin_list
+{% endfor %}
+
+jenkins_restart_for_plugins:
+  service.running:
+    - name: jenkins
+    - watch:
+      {% for plugin in jenkins.plugins.installed %}
+      - cmd: jenkins_install_plugin_{{ plugin }}
+      {% endfor %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -33,6 +33,13 @@ jenkins_serving:
     - watch:
       - cmd: jenkins_listening
 
+jenkins_responding:
+  cmd.wait:
+    - name: "until {{ jenkins_cli('who-am-i') }}; do sleep 1; done"
+    - timeout: 60
+    - watch:
+      - cmd: jenkins_serving
+
 jenkins_updates_file:
   file.directory:
     - name: {{ "{0}/updates".format(jenkins.home) }}
@@ -55,7 +62,7 @@ restart_jenkins:
   cmd.wait:
     - name: {{ jenkins_cli('safe-restart') }}
     - require:
-      - cmd: jenkins_serving
+      - cmd: jenkins_responding
 
 reload_jenkins_config:
   cmd.wait:

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -15,6 +15,8 @@ jenkins_updates_file:
     - onlyif: test -d {{ jenkins.home }}/updates
     - unless: test -f {{ jenkins.home }}/updates/default.json
     - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ jenkins.home }}/updates/default.json"
+    - require:
+      - pkg: jenkins
 
 restart_jenkins:
   cmd.wait:
@@ -32,6 +34,7 @@ jenkins_install_plugin_{{ plugin }}:
     - timeout: 360
     - require:
       - service: jenkins
+      - cmd: jenkins_updates_file
     - watch_in:
       - cmd: restart_jenkins
 {% endfor %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -6,8 +6,8 @@ include:
 {%- macro fmtarg(prefix, value)-%}
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
-{%- macro jenkins_cli(cmd, strargs) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, strargs]) }}
+{%- macro jenkins_cli(cmd) -%}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
 {%- endmacro -%}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}
@@ -25,16 +25,16 @@ jenkins_updates_file:
 
 restart_jenkins:
   cmd.wait:
-    - name: {{ jenkins_cli('safe-restart', '') }}
+    - name: {{ jenkins_cli('safe-restart') }}
 
 reload_jenkins_config:
   cmd.wait:
-    - name: {{ jenkins_cli('reload-configuration', '') }}
+    - name: {{ jenkins_cli('reload-configuration') }}
 
 {% for plugin in jenkins.plugins.installed %}
 jenkins_install_plugin_{{ plugin }}:
   cmd.run:
-    - unless: {{ jenkins_cli('list-plugins', '') }} | grep {{ plugin }}
+    - unless: {{ jenkins_cli('list-plugins') }} | grep {{ plugin }}
     - name: {{ jenkins_cli('install-plugin', plugin) }}
     - timeout: 360
     - require:

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -13,7 +13,7 @@ jenkins_updates_directory:
 
 jenkins_updates_file:
   cmd.run:
-    - unless: test -f /var/lib/jenkins/updates/default.json
+    - unless: test -f {{ jenkins.home }}/updates/default.json
     - name: "curl -L http://updates.jenkins-ci.org/update-center.json | sed '1d;$d' > {{ jenkins.home }}/updates/default.json"
 
 jenkins_started:

--- a/pillar.example
+++ b/pillar.example
@@ -4,6 +4,10 @@ jenkins:
     home: /usr/local/jenkins
     user: jenkins
     group: www-data
-    server_name: ci.example.com
+    server_name: localhost
+    master_url: http://localhost:8080
+    plugins:
+      installed:
+        - greenballs
     pkgs:
       - jenkins

--- a/pillar.example
+++ b/pillar.example
@@ -1,7 +1,7 @@
 jenkins:
   lookup:
     port: 80
-    home: /usr/local/jenkins
+    home: /var/lib/jenkins
     user: jenkins
     group: www-data
     server_name: localhost


### PR DESCRIPTION
Extending @jpic's PR #24 with support for:

- Authenticated `jenkins-cli` 
- Plugin disabling
- Simplifying `plugins.sls` refactors