### PR TITLE
#32 fix: Allowing nginx user/group to be overriden

### DIFF
--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -3,6 +3,8 @@
         'pkgs': ['jenkins'],
         'user': 'jenkins',
         'group': 'jenkins',
+        'nginx_user': 'www-data',
+        'nginx_group': 'www-data',
         'home': '/var/lib/jenkins',
         'port': '80',
         'server_name': None

--- a/jenkins/nginx.sls
+++ b/jenkins/nginx.sls
@@ -1,9 +1,11 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+
 /etc/nginx/sites-available/jenkins.conf:
   file.managed:
     - template: jinja
     - source: salt://jenkins/files/nginx.conf
-    - user: www-data
-    - group: www-data
+    - user: {{ jenkins.nginx_user }}
+    - group: {{ jenkins.nginx_group }}
     - mode: 440
     - require:
       - pkg: jenkins
@@ -11,8 +13,8 @@
 /etc/nginx/sites-enabled/jenkins.conf:
   file.symlink:
     - target: /etc/nginx/sites-available/jenkins.conf
-    - user: www-data
-    - group: www-data
+    - user: {{ jenkins.nginx_user }}
+    - group: {{ jenkins.nginx_group }}
 
 extend:
   nginx:


### PR DESCRIPTION
The proper fix for this is to refactor out common elements in `map.jinja` with distro-specific overrides, but I'm not quite sure how to do that idiomatically. Suggestions welcome.