### PR TITLE
Prevent duplicate builds on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - '2.7'
 
+branches:
+  only:
+    - master
+
 env:
   global:
     - BS_PIP_ALLOWED=1


### PR DESCRIPTION
Prevent a commit from being built twice:

- because it's a PR,
- **because it's a branch**.

After this commit, the second condition doesn't apply anymore.