### PR TITLE
Request jenkins-cli.jar directly from jenkins

### DIFF
--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -10,7 +10,7 @@
         'port': '80',
         'jenkins_port': 8080,
         'server_name': None,
-        'cli_path': '/var/cache/jenkins/war/WEB-INF/jenkins-cli.jar',
+        'cli_path': '/var/cache/jenkins/jenkins-cli.jar',
         'master_url': 'http://localhost:8080',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',


### PR DESCRIPTION
Continuation from #31. Don't reach into Jenkins' internal structure, just request it from the service and cache it

This is safe, because Jenkins serves the CLI binary unauthenticated even if global authentication is enabled.