### PR TITLE
Jenkins jobs

### DIFF
--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -47,3 +47,15 @@ jenkins_responding:
     - timeout: {{ timeout }}
     - watch:
       - cmd: jenkins_cli_jar
+
+restart_jenkins:
+  cmd.wait:
+    - name: {{ jenkins_cli('safe-restart') }}
+    - require:
+      - cmd: jenkins_responding
+
+reload_jenkins_config:
+  cmd.wait:
+    - name: {{ jenkins_cli('reload-configuration') }}
+    - require:
+      - cmd: jenkins_responding

--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -1,0 +1,49 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+
+{%- macro fmtarg(prefix, value)-%}
+{{ (prefix + ' ' + value) if value else '' }}
+{%- endmacro -%}
+{%- macro jenkins_cli(cmd) -%}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{%- endmacro -%}
+
+{% set timeout = 360 %}
+
+jenkins_listening:
+  pkg.installed:
+    - name: {{ jenkins.netcat_pkg }}
+  cmd.wait:
+    - name: "until nc -z localhost {{ jenkins.jenkins_port }}; do sleep 1; done"
+    - timeout: 10
+    - require:
+      - service: jenkins
+    - watch:
+      - service: jenkins
+
+jenkins_serving:
+  pkg.installed:
+    - name: curl
+
+  cmd.wait:
+    - name: "until (curl -I -L {{ jenkins.master_url }}/jnlpJars/jenkins-cli.jar | grep \"Content-Type: application/java-archive\"); do sleep 1; done"
+    - timeout: {{ timeout }}
+    - watch:
+      - cmd: jenkins_listening
+
+jenkins_cli_jar:
+  pkg.installed:
+    - name: curl
+
+  cmd.run:
+    - unless: test -f {{ jenkins.cli_path }}
+    - name: "curl -L -o {{ jenkins.cli_path }} {{ jenkins.master_url }}/jnlpJars/jenkins-cli.jar"
+    - require:
+      - pkg: jenkins_cli_jar
+      - cmd: jenkins_serving
+
+jenkins_responding:
+  cmd.wait:
+    - name: "until {{ jenkins_cli('who-am-i') }}; do sleep 1; done"
+    - timeout: {{ timeout }}
+    - watch:
+      - cmd: jenkins_cli_jar

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -1,0 +1,24 @@
+include:
+  - jenkins
+  - jenkins.cli
+
+{% from "jenkins/map.jinja" import jenkins with context %}
+
+{%- macro fmtarg(prefix, value)-%}
+{{ (prefix + ' ' + value) if value else '' }}
+{%- endmacro -%}
+{%- macro jenkins_cli(cmd) -%}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{%- endmacro -%}
+
+{% for job, path in jenkins.jobs.installed.iteritems() %}
+jenkins_install_job_{{ job }}:
+  cmd.run:
+    - unless: {{ jenkins_cli('list-jobs') }} | grep {{ job }}
+    - name: {{ jenkins_cli('create-job', job, '<', path) }}
+    - timeout: 360
+    - require:
+      - service: jenkins
+      - cmd: jenkins_updates_file
+      - cmd: jenkins_cli_jar
+{% endfor %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -17,5 +17,9 @@
             'installed': [],
             'disabled': [],
         },
+        'jobs': {
+            'installed': {},
+            'absent': []
+        }
     },
 }, merge=salt['pillar.get']('jenkins:lookup')) %}

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -31,18 +31,6 @@ jenkins_updates_file:
       - pkg: jenkins_updates_file
       - file: jenkins_updates_file
 
-restart_jenkins:
-  cmd.wait:
-    - name: {{ jenkins_cli('safe-restart') }}
-    - require:
-      - cmd: jenkins_responding
-
-reload_jenkins_config:
-  cmd.wait:
-    - name: {{ jenkins_cli('reload-configuration') }}
-    - require:
-      - cmd: jenkins_responding
-
 {% for plugin in jenkins.plugins.installed %}
 jenkins_install_plugin_{{ plugin }}:
   cmd.run:

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -1,5 +1,6 @@
 include:
   - jenkins
+  - jenkins.cli
 
 {% from "jenkins/map.jinja" import jenkins with context %}
 
@@ -11,46 +12,6 @@ include:
 {%- endmacro -%}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}
-{% set timeout = 360 %}
-
-jenkins_listening:
-  pkg.installed:
-    - name: {{ jenkins.netcat_pkg }}
-  cmd.wait:
-    - name: "until nc -z localhost {{ jenkins.jenkins_port }}; do sleep 1; done"
-    - timeout: 10
-    - require:
-      - service: jenkins
-    - watch:
-      - service: jenkins
-
-jenkins_serving:
-  pkg.installed:
-    - name: curl
-
-  cmd.wait:
-    - name: "until (curl -I -L {{ jenkins.master_url }}/jnlpJars/jenkins-cli.jar | grep \"Content-Type: application/java-archive\"); do sleep 1; done"
-    - timeout: {{ timeout }}
-    - watch:
-      - cmd: jenkins_listening
-
-jenkins_cli_jar:
-  pkg.installed:
-    - name: curl
-
-  cmd.run:
-    - unless: test -f {{ jenkins.cli_path }}
-    - name: "curl -L -o {{ jenkins.cli_path }} {{ jenkins.master_url }}/jnlpJars/jenkins-cli.jar"
-    - require:
-      - pkg: jenkins_cli_jar
-      - cmd: jenkins_serving
-
-jenkins_responding:
-  cmd.wait:
-    - name: "until {{ jenkins_cli('who-am-i') }}; do sleep 1; done"
-    - timeout: {{ timeout }}
-    - watch:
-      - cmd: jenkins_cli_jar
 
 jenkins_updates_file:
   file.directory:
@@ -87,7 +48,7 @@ jenkins_install_plugin_{{ plugin }}:
   cmd.run:
     - unless: {{ jenkins_cli('list-plugins') }} | grep {{ plugin }}
     - name: {{ jenkins_cli('install-plugin', plugin) }}
-    - timeout: {{ timeout }}
+    - timeout: 60
     - require:
       - service: jenkins
       - cmd: jenkins_updates_file


### PR DESCRIPTION
This depends on #35 

Much like declaratively installing plugins, this PR adds the ability to declaratively define jobs from XML files on-disk.

Example pillar:
```
jenkins:
  lookup:
    [...]
    jobs:
      installed:
        Master: /srv/extra/jenkins/jobs/Master.xml
        Tasks: /srv/extra/jenkins/jobs/Tasks.xml
        Publish: /srv/extra/jenkins/jobs/Publish.xml
```

The one thing this doesn't support is `salt://` URLs, since it's not part of my use case. (`/srv/extra/jenkins` is a private git repo, containing pipeline particulars and secrets)