### PR TITLE
Replaces netcat with lsof to be more compatible with RedHat distros.

### DIFF
--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -11,9 +11,9 @@
 
 jenkins_listening:
   pkg.installed:
-    - name: {{ jenkins.netcat_pkg }}
+    - name: lsof
   cmd.wait:
-    - name: "until nc -z localhost {{ jenkins.jenkins_port }}; do sleep 1; done"
+    - name: "until lsof -i :{{ jenkins.jenkins_port }}; do sleep 1; done"
     - timeout: 10
     - require:
       - service: jenkins

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -1,7 +1,6 @@
 {% set jenkins = salt['grains.filter_by']({
     'default': {
         'pkgs': ['jenkins'],
-        'netcat_pkg': 'netcat-openbsd',
         'user': 'jenkins',
         'group': 'jenkins',
         'nginx_user': 'www-data',


### PR DESCRIPTION
I found that the version of netcat available in CentOS (ncat-nmap package) does not have the -z flag being used. So i propose to make this state more portable by facilitating lsof instead.
