### PR TITLE
make use of jenkins_port in nginx.conf

### DIFF
--- a/jenkins/files/nginx.conf
+++ b/jenkins/files/nginx.conf
@@ -1,7 +1,7 @@
 {% from "jenkins/map.jinja" import jenkins with context %}
 
 upstream app_server {
-    server 127.0.0.1:8080 fail_timeout=0;
+    server 127.0.0.1:{{ jenkins.jenkins_port }} fail_timeout=0;
 }
 
 server {


### PR DESCRIPTION
Won't fail anymore on distros launching jenkins hardcoded on other ports than 8080. ArchLinux may be a sample