### PR TITLE
Change apt source file location

### DIFF
--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -32,6 +32,7 @@ jenkins:
     - baseurl: http://pkg.jenkins-ci.org/redhat
     - gpgkey: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
     {% elif grains['os_family'] == 'Debian' %}
+    - file: {{jenkins.deb_apt_source}}
     - name: deb http://pkg.jenkins-ci.org/debian binary/
     - key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
     {% endif %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -1,6 +1,7 @@
 {% set jenkins = salt['grains.filter_by']({
     'default': {
         'pkgs': ['jenkins'],
+        'deb_apt_source': '/etc/apt/sources.list.d/jenkins-ci.list',
         'netcat_pkg': 'netcat-openbsd',
         'user': 'jenkins',
         'group': 'jenkins',


### PR DESCRIPTION
Needed to remove the deb source, and didn't find it where it would be expected.  Salt, and most other sources wind up going in the default /etc/apt/sources.list.d directory.

For debian family OS:
Add pkgrepo.managed.file handling to init.sls
Set default in map.jinja to /etc/apt/sources.list.d/jenkins-ci.list as per Debian/Ubuntu default

