### PR TITLE
Added jinja template for Jenkins config

### DIFF
--- a/jenkins/files/jenkins.conf
+++ b/jenkins/files/jenkins.conf
@@ -117,7 +117,7 @@ JENKINS_DEBUG_LEVEL="5"
 #
 # Whether to enable access logging or not.
 #
-JENKINS_ENABLE_ACCESS_LOG="{{ jenkins.enable_acess_log }}"
+JENKINS_ENABLE_ACCESS_LOG="{{ jenkins.enable_access_log }}"
 
 ## Type:        integer
 ## Default:     100

--- a/jenkins/files/jenkins.conf
+++ b/jenkins/files/jenkins.conf
@@ -1,0 +1,145 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+## Path:        Development/Jenkins
+## Description: Jenkins Continuous Integration Server
+## Type:        string
+## Default:     "/var/lib/jenkins"
+## ServiceRestart: jenkins
+#
+# Directory where Jenkins store its configuration and working
+# files (checkouts, build reports, artifacts, ...).
+#
+JENKINS_HOME="{{ jenkins.home }}"
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# Java executable to run Jenkins
+# When left empty, we'll try to find the suitable Java.
+#
+JENKINS_JAVA_CMD=""
+
+## Type:        string
+## Default:     "jenkins"
+## ServiceRestart: jenkins
+#
+# Unix user account that runs the Jenkins daemon
+# Be careful when you change this, as you need to update
+# permissions of $JENKINS_HOME and /var/log/jenkins.
+#
+JENKINS_USER="{{ jenkins.user }}"
+
+## Type:        string
+## Default: "false"
+## ServiceRestart: jenkins
+#
+# Whether to skip potentially long-running chown at the
+# $JENKINS_HOME location. Do not enable this, "true", unless
+# you know what you're doing. See JENKINS-23273.
+#
+#JENKINS_INSTALL_SKIP_CHOWN="false"
+
+## Type: string
+## Default:     "-Djava.awt.headless=true"
+## ServiceRestart: jenkins
+#
+# Options to pass to java when running Jenkins.
+#
+JENKINS_JAVA_OPTIONS="-Djava.awt.headless=true"
+
+## Type:        integer(0:65535)
+## Default:     8080
+## ServiceRestart: jenkins
+#
+# Port Jenkins is listening on.
+# Set to -1 to disable
+#
+JENKINS_PORT="{{ jenkins.jenkins_port }}"
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# IP address Jenkins listens on for HTTP requests.
+# Default is all interfaces (0.0.0.0).
+#
+JENKINS_LISTEN_ADDRESS=""
+
+## Type:        integer(0:65535)
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# HTTPS port Jenkins is listening on.
+# Default is disabled.
+#
+JENKINS_HTTPS_PORT=""
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# Path to the keystore in JKS format (as created by the JDK 'keytool').
+# Default is disabled.
+#
+JENKINS_HTTPS_KEYSTORE=""
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# Password to access the keystore defined in JENKINS_HTTPS_KEYSTORE.
+# Default is disabled.
+#
+JENKINS_HTTPS_KEYSTORE_PASSWORD=""
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# IP address Jenkins listens on for HTTPS requests.
+# Default is disabled.
+#
+JENKINS_HTTPS_LISTEN_ADDRESS=""
+
+
+## Type:        integer(1:9)
+## Default:     5
+## ServiceRestart: jenkins
+#
+# Debug level for logs -- the higher the value, the more verbose.
+# 5 is INFO.
+#
+JENKINS_DEBUG_LEVEL="5"
+
+## Type:        yesno
+## Default:     no
+## ServiceRestart: jenkins
+#
+# Whether to enable access logging or not.
+#
+JENKINS_ENABLE_ACCESS_LOG="no"
+
+## Type:        integer
+## Default:     100
+## ServiceRestart: jenkins
+#
+# Maximum number of HTTP worker threads.
+#
+JENKINS_HANDLER_MAX="100"
+
+## Type:        integer
+## Default:     20
+## ServiceRestart: jenkins
+#
+# Maximum number of idle HTTP worker threads.
+#
+JENKINS_HANDLER_IDLE="20"
+
+## Type:        string
+## Default:     ""
+## ServiceRestart: jenkins
+#
+# Pass arbitrary arguments to Jenkins.
+# Full option list: java -jar jenkins.war --help
+#
+JENKINS_ARGS=""

--- a/jenkins/files/jenkins.conf
+++ b/jenkins/files/jenkins.conf
@@ -117,7 +117,7 @@ JENKINS_DEBUG_LEVEL="5"
 #
 # Whether to enable access logging or not.
 #
-JENKINS_ENABLE_ACCESS_LOG="no"
+JENKINS_ENABLE_ACCESS_LOG="{{ jenkins.enable_acess_log }}"
 
 ## Type:        integer
 ## Default:     100

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -45,3 +45,22 @@ jenkins:
     - enable: True
     - watch:
       - pkg: jenkins
+
+
+{% if grains['os_family'] in ['RedHat', 'Debian'] %}
+jenkins config:
+  file.managed:
+    {% if grains['os_family'] == 'RedHat' %}
+    - name: /etc/sysconfig/jenkins
+    {% elif grains['os_family'] == 'Debian' %}
+    - name: /etc/default/jenkins
+    {% endif %}
+    - template: jinja
+    - source: salt://jenkins/files/jenkins.conf
+    - user: root
+    - group: root
+    - mode: 400
+    - require:
+      - pkg: jenkins
+{% endif %}
+

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -13,6 +13,7 @@
         'server_name': None,
         'cli_path': '/var/cache/jenkins/jenkins-cli.jar',
         'master_url': 'http://localhost:8080',
+	'enable_access_log': 'no',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
             'installed': [],


### PR DESCRIPTION
Included an extra step in init.sls to apply the Jinja template to the Jenkins config file - allows setting the listen port and other variables. This just includes the bare essentials - more work could be done to include HTTPS and other settings in the template.
