### PR TITLE
Generalise jenkins_listening command for RedHat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,3 +31,15 @@ Pillar customizations:
         user: jenkins
         group: www-data
         server_name: ci.example.com
+
+Concerning the file cli.sls
+===========================
+
+Due to differences in the scope of functionality of netcat between RedHat and Debian/other Linux distributions, nc -z does not work on RedHat since the option -z simply does not exist. Hence by default, RedHat distro will use curl instead. If you are on Debian distro, please feel free to use a custom versin of netcat. You can define that in your pillar file as netcat_pkg: your_nc_package.
+
+Contributing to This Project
+============================
+
+1. Fork this repository.
+2. If you need to include this repo in a git superproject, then make your fork a git submodule.
+3. Submit Pull Request when you have developed a new feature or made a fix.

--- a/jenkins/macros/cli_macro.jinja
+++ b/jenkins/macros/cli_macro.jinja
@@ -1,0 +1,14 @@
+{% from "jenkins/map.jinja" import jenkins with context %}
+
+{# All Jinja macros used in cli.sls #}
+{%- macro fmtarg(prefix, value)-%}
+{{ (prefix + ' ' + value) if value else '' }}
+{%- endmacro -%}
+
+{%- macro jenkins_cli(cmd) -%}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{%- endmacro -%}
+
+{%- macro jenkins_listen() -%}
+{{ ' '.join(['curl', jenkins.master_url + ':' + jenkins.jenkins_port|string]) }}
+{%- endmacro -%}


### PR DESCRIPTION
1. Put all macros outside cli.sls into a new directory
   called macros. All future macros will be stored as
   separate files here. The names of the files will be
   nameOfSlsFile_macro.jinja. When any sls file will
   use the particular macros, all of them should be placed
   there.

2. Imported macros into cli.sls.

3. Namespaced macros in cli.sls as cli_macro. Do similar
   namespacing for future macro imports.

4. Generalise listening_tool to be curl for Redhat and
   jenkins.netcat_pkg for other distro. The latter is
   completely backward compatible and can be set by the user
   via pillar.

Effect: Now cli.sls works out of the box for Centos 7. I have
not tested on other Redhat distros yet.