### PR TITLE
Add support for stable jenkins

### DIFF
--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -26,15 +26,19 @@ jenkins_user:
 
 jenkins:
   {% if grains['os_family'] in ['RedHat', 'Debian'] %}
+    {% set repo_suffix = '' %}
+    {% if jenkins.stable %}
+      {% set repo_suffix = '-stable' %}
+    {% endif %}
   pkgrepo.managed:
     - humanname: Jenkins upstream package repository
     {% if grains['os_family'] == 'RedHat' %}
-    - baseurl: http://pkg.jenkins-ci.org/redhat
-    - gpgkey: http://pkg.jenkins-ci.org/redhat/jenkins-ci.org.key
+    - baseurl: http://pkg.jenkins-ci.org/redhat{{ repo_suffix }}
+    - gpgkey: http://pkg.jenkins-ci.org/redhat{{ repo_suffix }}/jenkins-ci.org.key
     {% elif grains['os_family'] == 'Debian' %}
     - file: {{jenkins.deb_apt_source}}
-    - name: deb http://pkg.jenkins-ci.org/debian binary/
-    - key_url: http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
+    - name: deb http://pkg.jenkins-ci.org/debian{{ repo_suffix }} binary/
+    - key_url: http://pkg.jenkins-ci.org/debian{{ repo_suffix }}/jenkins-ci.org.key
     {% endif %}
     - require_in:
       - pkg: jenkins

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -21,6 +21,7 @@
         'jobs': {
             'installed': {},
             'absent': []
-        }
+        },
+        'stable': False
     },
 }, merge=salt['pillar.get']('jenkins:lookup')) %}


### PR DESCRIPTION
This https://github.com/saltstack-formulas/jenkins-formula/pull/37/files has become stale and not merged, sending a new copy so it could be merged right away.
Adds support for stable release for debian and redhat.

closes https://github.com/saltstack-formulas/jenkins-formula/issues/9

@marianuspotratz @gravyboat
