### PR TITLE
Bugfix/cli

### DIFF
--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -4,7 +4,7 @@
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
 {%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
 {%- endmacro -%}
 
 {% set timeout = 360 %}
@@ -31,14 +31,10 @@ jenkins_serving:
       - cmd: jenkins_listening
 
 jenkins_cli_jar:
-  pkg.installed:
-    - name: curl
-
   cmd.run:
     - unless: test -f {{ jenkins.cli_path }}
     - name: "curl -L -o {{ jenkins.cli_path }} {{ jenkins.master_url }}/jnlpJars/jenkins-cli.jar"
     - require:
-      - pkg: jenkins_cli_jar
       - cmd: jenkins_serving
 
 jenkins_responding:

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -8,7 +8,7 @@ include:
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
 {%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
 {%- endmacro -%}
 
 {% for job, path in jenkins.jobs.installed.iteritems() %}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -12,7 +12,7 @@
         'jenkins_port': 8080,
         'server_name': None,
         'cli_path': '/var/cache/jenkins/jenkins-cli.jar',
-        'cli_timeout': 30,
+        'cli_timeout': 60,
         'master_url': 'http://localhost:8080',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -8,7 +8,7 @@ include:
 {{ (prefix + ' ' + value) if value else '' }}
 {%- endmacro -%}
 {%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd]) }} {{ ' '.join(varargs) }}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
 {%- endmacro -%}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}


### PR DESCRIPTION
Fixes a few CLI issues

* No need to require pkg curl for a 2nd time, it requires something that requires curl already
* `pkg: jenkins_cli_jar` should be `cmd: jenkins_cli_jar`, but `jenkins_cli_jar` cant depend on itself, so removed
* need to use authentication for CLI to work. It's as easy as using the contents of a file during jar usage
* Add `cli_timeout` for cli `until`
* Based off #58 