### PR TITLE
Added support for http/ssh connection mode for CLI client

### DIFF
--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -1,11 +1,5 @@
 {% from "jenkins/map.jinja" import jenkins with context %}
-
-{%- macro fmtarg(prefix, value)-%}
-{{ (prefix + ' ' + value) if value else '' }}
-{%- endmacro -%}
-{%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
-{%- endmacro -%}
+{% from 'jenkins/macros.jinja' import jenkins_cli with context %}
 
 {% set timeout = 360 %}
 

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -3,13 +3,7 @@ include:
   - jenkins.cli
 
 {% from "jenkins/map.jinja" import jenkins with context %}
-
-{%- macro fmtarg(prefix, value)-%}
-{{ (prefix + ' ' + value) if value else '' }}
-{%- endmacro -%}
-{%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
-{%- endmacro -%}
+{% from 'jenkins/macros.jinja' import jenkins_cli with context %}
 
 {% for job, path in jenkins.jobs.installed.iteritems() %}
 jenkins_install_job_{{ job }}:

--- a/jenkins/macros.jinja
+++ b/jenkins/macros.jinja
@@ -1,0 +1,17 @@
+{%- from 'jenkins/map.jinja' import jenkins with context -%}
+
+{%- macro fmtarg(prefix, value) -%}
+{{ (prefix + ' ' + value) if value else '' }}
+{%- endmacro -%}
+
+{%- macro jenkins_cli_auth_params(connection_mode) -%}
+{%- if connection_mode == 'ssh' -%}
+-ssh -user {{ jenkins.cli.ssh_user }}
+{%- else -%}
+-http -auth {{ jenkins.cli.http_auth }}
+{%- endif -%}
+{%- endmacro -%}
+
+{%- macro jenkins_cli(cmd) -%}
+{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), jenkins_cli_auth_params(jenkins.cli.connection_mode), cmd]) }} {{ ' '.join(varargs) }}
+{%- endmacro -%}

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -14,6 +14,11 @@
         'server_name': None,
         'cli_path': '/var/cache/jenkins/jenkins-cli.jar',
         'cli_timeout': 60,
+        'cli': {
+            'connection_mode': 'http',
+            'ssh_user': '',
+            'http_auth': 'admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)'
+        },
         'master_url': 'http://localhost:8080',
         'plugins': {
             'updates_source': 'http://updates.jenkins-ci.org/update-center.json',

--- a/jenkins/plugins.sls
+++ b/jenkins/plugins.sls
@@ -3,13 +3,7 @@ include:
   - jenkins.cli
 
 {% from "jenkins/map.jinja" import jenkins with context %}
-
-{%- macro fmtarg(prefix, value)-%}
-{{ (prefix + ' ' + value) if value else '' }}
-{%- endmacro -%}
-{%- macro jenkins_cli(cmd) -%}
-{{ ' '.join(['java', '-jar', jenkins.cli_path, '-s', jenkins.master_url, fmtarg('-i', jenkins.get('privkey')), cmd, '--username admin --password $(cat /var/lib/jenkins/secrets/initialAdminPassword)']) }} {{ ' '.join(varargs) }}
-{%- endmacro -%}
+{% from 'jenkins/macros.jinja' import jenkins_cli with context %}
 
 {% set plugin_cache = "{0}/updates/default.json".format(jenkins.home) %}
 


### PR DESCRIPTION
Remoting connection mode is deprecated due to security reasons and you should use ssh or http connection mode instead. 
For `ssh` connection mode you have to configure `cli.ssh_user`, for `http` (default connection mode) `cli.http_auth` (format username:apitoken or username:password). `remoting` connection mode is available too, but you have to login via cli before calling any other commands.
`http` is default connection mode and it should work as is, for `ssh` you have to enable SSHD port in Global security configuration, for `remoting` you have to enable CLI over remoting.
If you have cached older jenkins-cli.jar version, you have to download new one (delete cached file).
See https://jenkins.io/doc/book/managing/cli/#using-the-cli-client for details.

Macros are refactored to seperate file.
