### PR TITLE
#47: make netcat flag configurable

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -22,6 +22,15 @@ platforms:
       run_command: /sbin/init
       privileged: true
       pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-7
+    driver_config:
+      image: centos:7
+      provision_command:
+        - yum -y install initscripts
+      platform: rhel
+      run_command: /sbin/init
+      privileged: true
+      pid_one_command: /usr/lib/systemd/systemd
 #  - name: amazonlinux
 #    driver_config:
 #      image: amazonlinux:latest
@@ -50,10 +59,15 @@ suites:
             '*':
               - jenkins
               - nginx
+              - sun-java
+        sun-java.sls:
+          java:
+            version_name: jdk1.8.0_131
+            source_url: http://download.oracle.com/otn-pub/java/jdk/8u131-b11/d54c1d3a095b4ff2b6607d096fa80163/jdk-8u131-linux-x64.tar.gz
+            source_hash: 62b215bdfb48bace523723cdbb2157c665e6a25429c73828a32f00e587301236
         jenkins.sls:
           jenkins:
             lookup:
-              netcat_pkg: netcat
               java_executable: /usr/lib/java/bin/java
               jenkins_port: 8080
               port: 80

--- a/jenkins/cli.sls
+++ b/jenkins/cli.sls
@@ -7,7 +7,7 @@ jenkins_listening:
   pkg.installed:
     - name: {{ jenkins.netcat_pkg }}
   cmd.wait:
-    - name: "until nc -z localhost {{ jenkins.jenkins_port }}; do sleep 1; done"
+    - name: "until nc {{ jenkins.netcat_flag }} localhost {{ jenkins.jenkins_port }}; do sleep 1; done"
     - timeout: {{ jenkins.cli_timeout }}
     - require:
       - service: jenkins

--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -1,0 +1,37 @@
+jenkins:
+  stable: False
+  pkgs:
+    - jenkins
+  deb_apt_source: /etc/apt/sources.list.d/jenkins-ci.list
+  netcat_pkg: netcat-openbsd
+  netcat_flag: -z
+  user: jenkins
+  group: jenkins
+  nginx_user: www-data
+  nginx_group: www-data
+  home: /var/lib/jenkins
+  java_args: -Djava.awt.headless=true
+  java_executable: /usr/bin/java
+  jenkins_args:
+  max_open_files: 32768
+  umask: 027
+  enable_access_log: no
+  access_log: --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access.log
+  port: 80
+  jenkins_port: 8080
+  server_name: None
+  cli_path: /var/cache/jenkins/jenkins-cli.jar
+  cli_timeout: 60
+  cli:
+    connection_mode: http
+    ssh_user:
+    http_auth: admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)
+  master_url: http://localhost:8080
+  plugins:
+    updates_source: http://updates.jenkins-ci.org/update-center.json
+    timeout: 30
+    installed: []
+    disabled: []
+  jobs:
+    installed: {}
+    absent: []

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -3,6 +3,7 @@
         'pkgs': ['jenkins'],
         'deb_apt_source': '/etc/apt/sources.list.d/jenkins-ci.list',
         'netcat_pkg': 'netcat-openbsd',
+        'netcat_flag': '-z',
         'user': 'jenkins',
         'group': 'jenkins',
         'nginx_user': 'www-data',

--- a/jenkins/map.jinja
+++ b/jenkins/map.jinja
@@ -1,42 +1,12 @@
-{% set jenkins = salt['grains.filter_by']({
-    'default': {
-        'pkgs': ['jenkins'],
-        'deb_apt_source': '/etc/apt/sources.list.d/jenkins-ci.list',
-        'netcat_pkg': 'netcat-openbsd',
-        'netcat_flag': '-z',
-        'user': 'jenkins',
-        'group': 'jenkins',
-        'nginx_user': 'www-data',
-        'nginx_group': 'www-data',
-        'home': '/var/lib/jenkins',
-        'java_args': '-Djava.awt.headless=true',
-        'java_executable': '/usr/bin/java',
-        'jenkins_args': '',
-        'max_open_files': '32768',
-        'umask': '027',
-        'enable_access_log': 'no',
-        'access_log': '--accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access.log',
-        'port': '80',
-        'jenkins_port': 8080,
-        'server_name': None,
-        'cli_path': '/var/cache/jenkins/jenkins-cli.jar',
-        'cli_timeout': 60,
-        'cli': {
-            'connection_mode': 'http',
-            'ssh_user': '',
-            'http_auth': 'admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)'
-        },
-        'master_url': 'http://localhost:8080',
-        'plugins': {
-            'updates_source': 'http://updates.jenkins-ci.org/update-center.json',
-            'timeout': 30,
-            'installed': [],
-            'disabled': [],
-        },
-        'jobs': {
-            'installed': {},
-            'absent': []
-        },
-        'stable': False
-    },
-}, merge=salt['pillar.get']('jenkins:lookup')) %}
+{% import_yaml "jenkins/defaults.yaml" as defaults %}
+{% import_yaml "jenkins/osmap.yaml" as osmap %}
+
+{% set jenkins = salt['grains.filter_by'](
+  defaults,
+  merge=salt['grains.filter_by'](
+        osmap,
+        grain='os_family',
+        merge=salt['pillar.get']('jenkins:lookup', {}),),
+  base = 'jenkins',
+)
+%}

--- a/jenkins/osmap.yaml
+++ b/jenkins/osmap.yaml
@@ -1,0 +1,7 @@
+Debian:
+    netcat_pkg: netcat-openbsd
+    netcat_flag: -z
+
+RedHat:
+    netcat_pkg: nmap-ncat
+    netcat_flag: --recv-only


### PR DESCRIPTION
An attempt to work around the inconsistent ncat flags using another optional pillar value - preserves default behavior, tested on CentOS 7 (with nmap-ncat) and `netcat_flag` set to `--recv-only`