### PR TITLE
Fixed default config values

### DIFF
--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -12,7 +12,7 @@ jenkins:
   home: /var/lib/jenkins
   java_args: -Djava.awt.headless=true
   java_executable: /usr/bin/java
-  jenkins_args:
+  jenkins_args: ''
   max_open_files: 32768
   umask: '027'
   enable_access_log: no

--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -14,7 +14,7 @@ jenkins:
   java_executable: /usr/bin/java
   jenkins_args:
   max_open_files: 32768
-  umask: 027
+  umask: '027'
   enable_access_log: no
   access_log: --accessLoggerClassName=winstone.accesslog.SimpleAccessLogger --simpleAccessLogger.format=combined --simpleAccessLogger.file=/var/log/$NAME/access.log
   port: 80


### PR DESCRIPTION
Default values without '' breaks config file for Debian in this case. They are not printed as string but interpreted to different values.