### PR TITLE
Adding $JAVA variable to jenkins.conf for Debian

### DIFF
--- a/jenkins/files/Debian/jenkins.conf
+++ b/jenkins/files/Debian/jenkins.conf
@@ -4,6 +4,9 @@
 # pulled in from the init script; makes things easier.
 NAME=jenkins
 
+# Java executable to run Jenkins
+JAVA="{{ jenkins.java_executable }}"
+
 # arguments to pass to java
 
 # Allow graphs etc. to work even when an X server is present


### PR DESCRIPTION
The $JAVA variable is missing from jenkins.conf for Debian, which caused
the service to fail to start, due to the Java executable path not being
present.