### PR TITLE
Add Java executable path to Debian config

### DIFF
--- a/jenkins/files/Debian/jenkins.conf
+++ b/jenkins/files/Debian/jenkins.conf
@@ -4,6 +4,9 @@
 # pulled in from the init script; makes things easier.
 NAME=jenkins
 
+# location of java
+JAVA=/usr/bin/java
+
 # arguments to pass to java
 
 # Allow graphs etc. to work even when an X server is present


### PR DESCRIPTION
The $JAVA variable is missing from jenkins.conf for Debian. This causes
the service to fail to start, due to the Java executable path not being
present.