### PR TITLE
Automatically update job configurations

### DIFF
--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -15,4 +15,14 @@ jenkins_install_job_{{ job }}:
       - service: jenkins
       - cmd: jenkins_updates_file
       - cmd: jenkins_cli_jar
+
+jenkins_update_job_{{ job }}:
+  cmd.run:
+    - unless: diff -w {{ jenkins.home }}/jobs/{{ job }}/config.xml {{ path }}
+    - name: {{ jenkins_cli('update-job', job, '<', path) }}
+    - timeout: 360
+    - require:
+      - service: jenkins
+      - cmd: jenkins_updates_file
+      - cmd: jenkins_cli_jar
 {% endfor %}


### PR DESCRIPTION
I've used `diff -w` to build an `unless` clause so that this only happens when the files really change. As the jenkins cli will modify the XML provided, stripping any line feeds at the end etc, I found using `diff -w` slightly easier to work with.

fixes #78

- Jobs were not automatically updated when applying state with edits to the xml files
- If the job/name/config.xml and jobDefFolder/name.xml differ, update the job