### PR TITLE
Debian fixes

### DIFF
--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -10,6 +10,7 @@ jenkins:
   nginx_user: www-data
   nginx_group: www-data
   home: /var/lib/jenkins
+  daemon: /usr/bin/daemon
   java_args: -Djava.awt.headless=true
   java_executable: /usr/bin/java
   jenkins_args: ''

--- a/jenkins/files/Debian/jenkins.conf
+++ b/jenkins/files/Debian/jenkins.conf
@@ -1,4 +1,7 @@
 {%- from "jenkins/map.jinja" import jenkins with context -%}
+# This file is managed by salt
+# Local changes will be overwritten!
+#
 # defaults for Jenkins automation server
 
 # pulled in from the init script; makes things easier.

--- a/jenkins/files/Debian/jenkins.conf
+++ b/jenkins/files/Debian/jenkins.conf
@@ -4,6 +4,9 @@
 # pulled in from the init script; makes things easier.
 NAME=jenkins
 
+# jenkins home location
+JENKINS_HOME="{{ jenkins.home }}"
+
 # Java executable to run Jenkins
 JAVA="{{ jenkins.java_executable }}"
 
@@ -27,9 +30,6 @@ JENKINS_GROUP="{{ jenkins.group }}"
 
 # location of the jenkins war file
 JENKINS_WAR=/usr/share/$NAME/$NAME.war
-
-# jenkins home location
-JENKINS_HOME="{{ jenkins.home }}"
 
 # set this to false if you don't want Jenkins to run by itself
 # in this set up, you are expected to provide a servlet container

--- a/jenkins/files/Debian/jenkins.conf
+++ b/jenkins/files/Debian/jenkins.conf
@@ -13,6 +13,9 @@ JENKINS_HOME="{{ jenkins.home }}"
 # Java executable to run Jenkins
 JAVA="{{ jenkins.java_executable }}"
 
+# Daemon executable to start the Jenkins service
+DAEMON="{{ jenkins.daemon }}"
+
 # arguments to pass to java
 
 # Allow graphs etc. to work even when an X server is present


### PR DESCRIPTION
* The init script for Debian expects DAEMON to be set, so have it in the defaults file and configurable.
* Set JENKINS_HOME on top of the file allow it to be referenced in other config options.