### PR TITLE
fix wrong requisite in jobs.sls

### DIFF
--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -13,7 +13,6 @@ jenkins_install_job_{{ job }}:
     - timeout: 360
     - require:
       - service: jenkins
-      - cmd: jenkins_updates_file
       - cmd: jenkins_cli_jar
 
 jenkins_update_job_{{ job }}:
@@ -23,6 +22,5 @@ jenkins_update_job_{{ job }}:
     - timeout: 360
     - require:
       - service: jenkins
-      - cmd: jenkins_updates_file
       - cmd: jenkins_cli_jar
 {% endfor %}


### PR DESCRIPTION
You require jenkins_updates_file in jobs.sls but its only available on plugins.sls 