### PR TITLE
Fix for 'Jenkins service won't start if Jenkins user is not default'

### DIFF
--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -11,7 +11,6 @@ jenkins_user:
     - groups:
       - {{ jenkins.group }}
     - system: True
-    - home: {{ jenkins.home }}
     - shell: /bin/bash
     - require:
       - group: jenkins_group

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -11,6 +11,7 @@ jenkins_user:
     - groups:
       - {{ jenkins.group }}
     - system: True
+    - home: {{ jenkins.home }}
     - shell: /bin/bash
     - require:
       - group: jenkins_group

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -6,14 +6,6 @@ jenkins_group:
     - system: True
 
 jenkins_user:
-  file.directory:
-    - name: {{ jenkins.home }}
-    - user: {{ jenkins.user }}
-    - group: {{ jenkins.group }}
-    - mode: 0755
-    - require:
-      - user: jenkins_user
-      - group: jenkins_group
   user.present:
     - name: {{ jenkins.user }}
     - groups:
@@ -23,6 +15,18 @@ jenkins_user:
     - shell: /bin/bash
     - require:
       - group: jenkins_group
+
+{% for dir in ['/var/log/jenkins','/var/cache/jenkins',jenkins.home] %}
+{{ dir }}:
+  file.directory:
+    - user: {{ jenkins.user }}
+    - group: {{ jenkins.group }}
+    - mode: 0755
+    - makedirs: True
+    - require:
+      - user: jenkins_user
+      - group: jenkins_group
+{% endfor %}
 
 jenkins:
   {% if grains['os_family'] in ['RedHat', 'Debian'] %}


### PR DESCRIPTION
**Issue**:
If we change Jenkins user from default user 'jenkins' to any other user in pillars, the Jenkins service won't start because ownership of /var/log/jenkins and /var/cache/jenkins is not updated to the new user. In this case, Jenkins service status will be.
`
jenkins dead but pid file exists
`

**Fix:**
This commit updates ownership of both  '/var/log/jenkins' and '/var/cache/jenkins'  along with Jenkins home directory, to the user/group mentioned in pillars