### PR TITLE
iteritems() -> items() (Python 3.6)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Assumes you have some way to copy your config to the server, e.g.
 
 .. code-block:: yaml
 
-    {% for job, path in salt['pillar.get']('jenkins:lookup:jobs:installed', {}).iteritems() %}
+    {% for job, path in salt['pillar.get']('jenkins:lookup:jobs:installed', {}).items() %}
     jenkins-host_job_definition_{{ job }}:
       file.managed:
         - name: {{ path }}

--- a/jenkins/jobs.sls
+++ b/jenkins/jobs.sls
@@ -5,7 +5,7 @@ include:
 {% from "jenkins/map.jinja" import jenkins with context %}
 {% from 'jenkins/macros.jinja' import jenkins_cli with context %}
 
-{% for job, path in jenkins.jobs.installed.iteritems() %}
+{% for job, path in jenkins.jobs.installed.items() %}
 jenkins_install_job_{{ job }}:
   cmd.run:
     - unless: {{ jenkins_cli('list-jobs') }} | grep {{ job }}


### PR DESCRIPTION
Ensure Python 3.6 compatibility.

Tested on FreeBSD 11.2 with `salt-ssh` to Ubuntu 18.04.