### PR TITLE
Correct domain for packages and updates

### DIFF
--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -30,7 +30,7 @@ jenkins:
     http_auth: admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)
   master_url: http://localhost:8080
   plugins:
-    updates_source: http://updates.jenkins-ci.org/update-center.json
+    updates_source: http://updates.jenkins.io/update-center.json
     timeout: 30
     installed: []
     disabled: []

--- a/jenkins/defaults.yaml
+++ b/jenkins/defaults.yaml
@@ -30,7 +30,7 @@ jenkins:
     http_auth: admin:$(cat /var/lib/jenkins/secrets/initialAdminPassword)
   master_url: http://localhost:8080
   plugins:
-    updates_source: http://updates.jenkins.io/update-center.json
+    updates_source: https://updates.jenkins.io/update-center.json
     timeout: 30
     installed: []
     disabled: []

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -42,12 +42,12 @@ jenkins:
   pkgrepo.managed:
     - humanname: Jenkins upstream package repository
     {% if grains['os_family'] == 'RedHat' %}
-    - baseurl: http://pkg.jenkins.io/redhat{{ repo_suffix }}
-    - gpgkey: http://pkg.jenkins.io/redhat{{ repo_suffix }}/jenkins.io.key
+    - baseurl: https://pkg.jenkins.io/redhat{{ repo_suffix }}
+    - gpgkey: https://pkg.jenkins.io/redhat{{ repo_suffix }}/jenkins.io.key
     {% elif grains['os_family'] == 'Debian' %}
     - file: {{jenkins.deb_apt_source}}
-    - name: deb http://pkg.jenkins.io/debian{{ repo_suffix }} binary/
-    - key_url: http://pkg.jenkins.io/debian{{ repo_suffix }}/jenkins.io.key
+    - name: deb https://pkg.jenkins.io/debian{{ repo_suffix }} binary/
+    - key_url: https://pkg.jenkins.io/debian{{ repo_suffix }}/jenkins.io.key
     {% endif %}
     - require_in:
       - pkg: jenkins

--- a/jenkins/init.sls
+++ b/jenkins/init.sls
@@ -42,12 +42,12 @@ jenkins:
   pkgrepo.managed:
     - humanname: Jenkins upstream package repository
     {% if grains['os_family'] == 'RedHat' %}
-    - baseurl: http://pkg.jenkins-ci.org/redhat{{ repo_suffix }}
-    - gpgkey: http://pkg.jenkins-ci.org/redhat{{ repo_suffix }}/jenkins-ci.org.key
+    - baseurl: http://pkg.jenkins.io/redhat{{ repo_suffix }}
+    - gpgkey: http://pkg.jenkins.io/redhat{{ repo_suffix }}/jenkins.io.key
     {% elif grains['os_family'] == 'Debian' %}
     - file: {{jenkins.deb_apt_source}}
-    - name: deb http://pkg.jenkins-ci.org/debian{{ repo_suffix }} binary/
-    - key_url: http://pkg.jenkins-ci.org/debian{{ repo_suffix }}/jenkins-ci.org.key
+    - name: deb http://pkg.jenkins.io/debian{{ repo_suffix }} binary/
+    - key_url: http://pkg.jenkins.io/debian{{ repo_suffix }}/jenkins.io.key
     {% endif %}
     - require_in:
       - pkg: jenkins


### PR DESCRIPTION
This PR is a minor change, jenkins moved to a new main domain which caused the formula to fail.

Updated domain jenkins-ci.org to jenkins.io
